### PR TITLE
prevent image cropping in modal viewer

### DIFF
--- a/src/css/components/_pin-modal-viewer.scss
+++ b/src/css/components/_pin-modal-viewer.scss
@@ -1,20 +1,13 @@
 .pin-modal-viewer {
-  position: relative;
   display: flex;
+  position: relative;
   align-items: center;
   align-self: stretch;
   background-color: $gray-light;
-  width: 100%;
   overflow: hidden;
 
-  &::after {
-    display: block;
-    padding-bottom: 100%;
-    content: '';
-  }
-
   .pin-modal-img {
-    position: absolute;
+    width: 100%;
     height: auto;
   }
 }


### PR DESCRIPTION
The viewer was being fixed at a square which caused portrait images to crop the top and bottom.

fixes #100